### PR TITLE
fix(#1): add email_validator as dependency to validate emails

### DIFF
--- a/lib/src/types/string.dart
+++ b/lib/src/types/string.dart
@@ -1,3 +1,5 @@
+import 'package:email_validator/email_validator.dart';
+
 import 'dart:convert';
 import 'list.dart';
 import 'types.dart';
@@ -8,7 +10,7 @@ class AcanthisString extends AcanthisType<String> {
   AcanthisString email() {
     addCheck(AcanthisCheck<String>(
         onCheck: (value) =>
-            RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$').hasMatch(value),
+            EmailValidator.validate(value),
         error: 'Invalid email format',
         name: 'email'));
     return this;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  email_validator:
+    dependency: "direct main"
+    description:
+      name: email_validator
+      sha256: e9a90f27ab2b915a27d7f9c2a7ddda5dd752d6942616ee83529b686fc086221b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.17"
   file:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
+  email_validator: ^2.1.17
   
   # path: ^1.8.0
 


### PR DESCRIPTION
# Description

The email validator now uses the email_validator package

Fixes #1

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

